### PR TITLE
fix same chart digest always change bug.

### DIFF
--- a/internal/experimental/registry/cache.go
+++ b/internal/experimental/registry/cache.go
@@ -108,7 +108,15 @@ func (cache *Cache) FetchReference(ref *Reference) (*CacheRefSummary, error) {
 			if err != nil {
 				return &r, err
 			}
-			r.Manifest = &desc
+			descCopy := ocispec.Descriptor{
+				MediaType:   desc.MediaType,
+				Digest:      desc.Digest,
+				Size:        desc.Size,
+				URLs:        desc.URLs,
+				Annotations: desc.Annotations,
+				Platform:    desc.Platform,
+			}
+			r.Manifest = &descCopy
 			r.Config = &manifest.Config
 			numLayers := len(manifest.Layers)
 			if numLayers != 1 {
@@ -147,6 +155,9 @@ func (cache *Cache) FetchReference(ref *Reference) (*CacheRefSummary, error) {
 				return &r, err
 			}
 			r.Chart = ch
+
+			// no need to loop anymore
+			break
 		}
 	}
 	return &r, nil


### PR DESCRIPTION
在 `FetchReference` 的 range 循环中，给 `r.Manifest` 赋值了 `&desc`，`desc` 是随着 range 不断变化的，所以 `r.Manifest` 永远指向循环最后的一个 `desc`

永远不要使用 range 变量的引用作为传递值！
